### PR TITLE
[SPD-8] Added logic for handling update password/reset password API responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
   <link rel="icon" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="SpadeShaft" />
+  <meta name="description" content="Spadeshaft" />
   <meta data-rh="true" property="og:image" content="https://refine.dev/img/refine_social.png" />
   <meta data-rh="true" name="twitter:image" content="https://refine.dev/img/refine_social.png" />
   <title>
-    SpadeShaft
+    Spadeshaft
   </title>
 </head>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
   ProcessList,
   ProcessShow,
 } from "./pages/processes";
+import { UpdatePassword } from "./pages/updatePassword";
 import { dataProvider } from "./rest-data-provider";
 
 axiosHelper.setAxiosTokenInterceptor();
@@ -186,7 +187,7 @@ function App() {
                           Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                           Title={() => (
                             <Link to="/">
-                              <h1>SpadeShaft</h1>
+                              <h1>Spadeshaft</h1>
                             </Link>
                           )}
                         >
@@ -249,6 +250,10 @@ function App() {
                     <Route
                       path="/forgot-password"
                       element={<ForgotPassword />}
+                    />
+                    <Route
+                      path="/update-password"
+                      element={<UpdatePassword />}
                     />
                   </Route>
                 </Routes>

--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -1,4 +1,5 @@
 import { AuthBindings } from "@refinedev/core";
+import { notification } from "antd";
 import axios from "axios";
 
 export const ACCESS_TOKEN_KEY = "access";
@@ -62,6 +63,53 @@ export const authProvider: AuthBindings = {
     return {
       success: true,
       redirectTo: "/login",
+    };
+  },
+  forgotPassword: async ({ email }) => {
+    try {
+      const res = await axios.post(`${API_URL}/password/reset`, { email });
+
+      if (res.status === 200) {
+        notification.success({
+          message: "Password reset email sent",
+          description: "Please check your email for further instructions",
+        });
+        return {
+          success: true,
+        };
+      }
+    } catch {
+      /* empty */
+    }
+
+    return {
+      success: false,
+    };
+  },
+  updatePassword: async (params) => {
+    try {
+      const res = await axios.post(`${API_URL}/password/reset/confirm`, {
+        new_password1: params.password,
+        new_password2: params.password,
+        uid: params.uid,
+        token: params.token,
+      });
+
+      if (res.status === 200) {
+        notification.success({
+          message: "Password updated successfully",
+          description: "Login to your account using updated credentials",
+        });
+        return {
+          success: true,
+          redirectTo: "/login",
+        };
+      }
+    } catch {
+      /* empty */
+    }
+    return {
+      success: false,
     };
   },
   check: async () => {

--- a/src/pages/forgotPassword/index.tsx
+++ b/src/pages/forgotPassword/index.tsx
@@ -1,5 +1,5 @@
 import { AuthPage } from "@refinedev/antd";
 
 export const ForgotPassword = () => {
-  return <AuthPage type="forgotPassword" />;
+  return <AuthPage title="Spadeshaft" type="forgotPassword" />;
 };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,5 +1,12 @@
 import { AuthPage } from "@refinedev/antd";
 
 export const Login = () => {
-  return <AuthPage title="SpadeShaft" type="login" rememberMe={false} registerLink={false} />;
+  return (
+    <AuthPage
+      title="Spadeshaft"
+      type="login"
+      rememberMe={false}
+      registerLink={false}
+    />
+  );
 };

--- a/src/pages/updatePassword/index.tsx
+++ b/src/pages/updatePassword/index.tsx
@@ -1,0 +1,5 @@
+import { AuthPage } from "@refinedev/antd";
+
+export const UpdatePassword = () => {
+  return <AuthPage title="Spadeshaft" type="updatePassword" />;
+};


### PR DESCRIPTION
* Added logic for handling update password/reset password API responses
  * There are backend (Spade) changes required to make it work
* Unified app name throughout all pages (Spade**s**haft)