### PR TITLE
[SPD-32] Refactored permissions handling

### DIFF
--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -5,7 +5,6 @@ import axios from "axios";
 export const API_URL = "http://localhost:8000/api/v1";
 export const ACCESS_TOKEN_KEY = "access";
 export const REFRESH_TOKEN_KEY = "refresh";
-export const USER_PERMISSIONS_KEY = "userPermissions";
 export const USER_DATA_KEY = "userFullName";
 
 export type UserData = {
@@ -41,17 +40,6 @@ export const authProvider: AuthBindings = {
                     : null,
               })
             );
-          }
-
-          // Update permissions list on login
-          const resPermissions = await axios.get(`${API_URL}/permissions`, {
-            headers: {
-              authorization: `Bearer ${localStorage.getItem(ACCESS_TOKEN_KEY)}`,
-            },
-          });
-
-          if (resPermissions.status === 200) {
-            localStorage.setItem(USER_PERMISSIONS_KEY, JSON.stringify(resPermissions.data));
           }
 
           return {

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -66,13 +66,16 @@ const CustomRoutes = () => {
                   <img
                     src={collapsed ? spadeLogos[mode]["single"] : spadeLogos[mode]["full"]}
                     style={!collapsed ? { marginLeft: -13 } : undefined}
-                    alt="Spade logo"></img>
+                    alt="Spade logo"
+                  ></img>
                 </Link>
-              )}>
+              )}
+            >
               <Outlet />
             </ThemedLayoutV2>
           </Authenticated>
-        }>
+        }
+      >
         <Route index element={<NavigateToResource resource="files" />} />
         <Route path="/files">
           <Route
@@ -251,7 +254,8 @@ const CustomRoutes = () => {
           <Authenticated key="authenticated-outer" fallback={<Outlet />}>
             <NavigateToResource />
           </Authenticated>
-        }>
+        }
+      >
         <Route path="/login" element={<Login />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/update-password" element={<UpdatePassword />} />


### PR DESCRIPTION
* User permissions are now stored in memory so they can be easily refetched by refreshing the page
* Moved permissions-related logic to access-control-provider.ts file where it really should be