### PR TITLE
hotfix: fix useOne/useMany v4→v5 migration - data→result

### DIFF
--- a/src/components/file-upload-button/index.tsx
+++ b/src/components/file-upload-button/index.tsx
@@ -26,7 +26,7 @@ const FileUploadButton: FC<FileUploadButtonProps> = ({ buttonProps, recordItemId
   const [selectedFile, setSelectedFile] = useState<UploadFile | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { data: fileData } = useOne({
+  const { result: fileData } = useOne({
     resource: "files",
     id: targetId,
     queryOptions: {
@@ -132,7 +132,7 @@ const FileUploadButton: FC<FileUploadButtonProps> = ({ buttonProps, recordItemId
           </Space>
         </Upload>
         {selectedFile && (
-          <RjsfForm schema={fileData?.data?.user_params ?? {}} validator={validator} onSubmit={onSubmit}>
+          <RjsfForm schema={fileData?.user_params ?? {}} validator={validator} onSubmit={onSubmit}>
             <Space align="start" className="workflow-modal__actions">
               <Button disabled={isLoading} htmlType="submit" type="primary">
                 Submit

--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -20,7 +20,7 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
   const targetId = recordItemId ?? identifier;
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { data: processData } = useOne({
+  const { result: processData } = useOne({
     resource: "processes",
     id: targetId,
     queryOptions: {
@@ -94,7 +94,7 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
         footer={<></>}
         className="workflow-modal"
       >
-        <RjsfForm schema={processData?.data?.user_params ?? {}} validator={validator} onSubmit={onSubmit}>
+        <RjsfForm schema={processData?.user_params ?? {}} validator={validator} onSubmit={onSubmit}>
           <Space align="start" className="workflow-modal__actions">
             <Button disabled={isLoading} htmlType="submit" type="primary">
               Submit

--- a/src/pages/files/show.tsx
+++ b/src/pages/files/show.tsx
@@ -43,7 +43,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: formatData, isLoading: formatIsLoading } = useOne({
+  const { result: formatData, isLoading: formatIsLoading } = useOne({
     resource: "fileformats",
     id: record?.format ?? "",
     queryOptions: {
@@ -52,7 +52,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: processorData, isLoading: processorIsLoading } = useOne({
+  const { result: processorData, isLoading: processorIsLoading } = useOne({
     resource: "fileprocessors",
     id: record?.processor ?? "",
     queryOptions: {
@@ -61,7 +61,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: processData, isLoading: processIsLoading } = useOne({
+  const { result: processData, isLoading: processIsLoading } = useOne({
     resource: "processes",
     id: record?.linked_process ?? "",
     queryOptions: {
@@ -70,7 +70,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: variableSetsData, isLoading: variableSetsIsLoading } = useMany({
+  const { result: variableSetsResult, isLoading: variableSetsIsLoading } = useMany({
     resource: "variable-sets",
     ids: record?.variable_sets || [],
     queryOptions: {
@@ -78,8 +78,9 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
       enabled: !!record?.variable_sets?.length,
     },
   });
+  const variableSetsData = variableSetsResult?.data;
 
-  const { data: userData, isLoading: userIsLoading } = useMany({
+  const { result: userResult, isLoading: userIsLoading } = useMany({
     resource: "users",
     ids: uploadTableProps?.dataSource?.map((item) => item?.user) ?? [],
     queryOptions: {
@@ -87,6 +88,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
       enabled: activeTabKey === "2" && !!uploadTableProps?.dataSource?.length,
     },
   });
+  const userData = userResult?.data;
 
   const getToPath = useGetToPath();
 

--- a/src/pages/processes/show.tsx
+++ b/src/pages/processes/show.tsx
@@ -27,7 +27,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
 
   const record = data?.data;
 
-  const { data: executorData, isLoading: executorIsLoading } = useOne({
+  const { result: executorData, isLoading: executorIsLoading } = useOne({
     resource: "executors",
     id: record?.executor || "",
     queryOptions: {
@@ -36,7 +36,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: variableSetsData, isLoading: variableSetsIsLoading } = useMany({
+  const { result: variableSetsResult, isLoading: variableSetsIsLoading } = useMany({
     resource: "variable-sets",
     ids: record?.variable_sets || [],
     queryOptions: {
@@ -44,6 +44,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
       enabled: !!record?.variable_sets?.length,
     },
   });
+  const variableSetsData = variableSetsResult?.data;
 
   const { tableProps: processRunsTableProps } = useTable({
     syncWithLocation: false,


### PR DESCRIPTION
Refine v5 changed useOne to return 'result' (unwrapped record) and useMany to return 'result.data' (unwrapped array) instead of 'data'. This caused file upload forms and process run forms to render with empty schemas, hiding all user-defined fields (ReleaseInfo, Commodity, etc.) even when user_params was correctly set in the database.

Affected:
- file-upload-button: schema was always {} because data was undefined
- process-run-button: same issue for process run forms
- files/show.tsx: format, processor, process, variable sets, user lookups
- processes/show.tsx: executor, variable sets, user lookups