### PR TITLE
hotfix: fix all v4→v5 useList/useMany/useParsed/notification gaps

### DIFF
--- a/src/components/file-upload-button/index.tsx
+++ b/src/components/file-upload-button/index.tsx
@@ -2,7 +2,7 @@ import { UploadOutlined } from "@ant-design/icons";
 import { BaseKey, useCan, useInvalidate, useOne, useParsed } from "@refinedev/core";
 import validator from "@rjsf/validator-ajv8";
 import type { GetProp } from "antd";
-import { Button, Modal, Space, Typography, Upload, UploadFile, UploadProps, notification } from "antd";
+import { Button, Modal, Space, Typography, Upload, UploadFile, UploadProps, App } from "antd";
 import { ButtonProps } from "antd/lib";
 import axios from "axios";
 import prettyBytes from "pretty-bytes";
@@ -19,9 +19,10 @@ type FileUploadButtonProps = {
 };
 
 const FileUploadButton: FC<FileUploadButtonProps> = ({ buttonProps, recordItemId, hideText }) => {
-  const { identifier } = useParsed();
+  const { notification } = App.useApp();
+  const { id } = useParsed();
   const invalidate = useInvalidate();
-  const targetId = recordItemId ?? identifier;
+  const targetId = recordItemId ?? id;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedFile, setSelectedFile] = useState<UploadFile | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -1,7 +1,7 @@
 import { PlayCircleOutlined } from "@ant-design/icons";
 import { BaseKey, useCan, useCustomMutation, useInvalidate, useOne, useParsed } from "@refinedev/core";
 import validator from "@rjsf/validator-ajv8";
-import { Button, Modal, Space, notification } from "antd";
+import { Button, Modal, Space, App } from "antd";
 import { ButtonProps } from "antd/lib";
 import { FC, useState } from "react";
 import { RjsfForm } from "../rjsf-form/rjsf-form";
@@ -14,10 +14,11 @@ type ProcessRunButtonProps = {
 };
 
 const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId, hideText }) => {
-  const { identifier } = useParsed();
+  const { notification } = App.useApp();
+  const { id } = useParsed();
   const { isLoading, mutate } = useCustomMutation();
   const invalidate = useInvalidate();
-  const targetId = recordItemId ?? identifier;
+  const targetId = recordItemId ?? id;
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { result: processData } = useOne({

--- a/src/pages/groups/create.tsx
+++ b/src/pages/groups/create.tsx
@@ -10,9 +10,10 @@ export const GroupCreate: React.FC<IResourceComponentsProps> = () => {
   const [selectedPermissions, setSelectedPermissions] = useState<number[]>([]);
 
   // Fetch permissions using useList hook
-  const { data: permissionsData, isLoading: permissionsLoading } = useList({
+  const { result: permissionsResult, isLoading: permissionsLoading } = useList({
     resource: "permissions",
   });
+  const permissionsData = permissionsResult?.data;
 
   const permissions = permissionsData?.data || [];
 

--- a/src/pages/groups/edit.tsx
+++ b/src/pages/groups/edit.tsx
@@ -12,11 +12,10 @@ export const GroupEdit: React.FC<IResourceComponentsProps> = () => {
   const [selectedPermissions, setSelectedPermissions] = useState<number[]>([]);
 
   // Fetch permissions using useList hook
-  const { data: permissionsData, isLoading: permissionsLoading } = useList({
+  const { result: permissionsResult, isLoading: permissionsLoading } = useList({
     resource: "permissions",
   });
-
-  const permissions = permissionsData?.data || [];
+  const permissions = permissionsResult?.data || [];
 
   // Set initial selected permissions from record
   useEffect(() => {

--- a/src/pages/groups/show.tsx
+++ b/src/pages/groups/show.tsx
@@ -12,9 +12,10 @@ export const GroupShow: React.FC<IResourceComponentsProps> = () => {
   const record = data?.data;
 
   // Fetch permissions
-  const { data: permissionsData } = useList({
+  const { result: permissionsResult } = useList({
     resource: "permissions",
   });
+  const permissionsData = permissionsResult?.data;
 
   // Map permission IDs to names
   const permissionNames = record?.permissions?.map((permissionId: string) => {

--- a/src/pages/processes/show.tsx
+++ b/src/pages/processes/show.tsx
@@ -67,7 +67,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const { data: userData, isLoading: userIsLoading } = useMany({
+  const { result: userResult, isLoading: userIsLoading } = useMany({
     resource: "users",
     ids: processRunsTableProps?.dataSource?.map((item) => item?.user) ?? [],
     queryOptions: {
@@ -75,6 +75,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
       enabled: activeTabKey === "2" && !!processRunsTableProps?.dataSource?.length,
     },
   });
+  const userData = userResult?.data;
 
   const getToPath = useGetToPath();
 

--- a/src/pages/users/create.tsx
+++ b/src/pages/users/create.tsx
@@ -13,17 +13,17 @@ export const UserCreate: React.FC<IResourceComponentsProps> = () => {
   const [selectedGroups, setSelectedGroups] = useState<number[]>([]);
 
   // Fetch permissions using useList hook
-  const { data: permissionsData, isLoading: permissionsLoading } = useList({
+  const { result: permissionsResult, isLoading: permissionsLoading } = useList({
     resource: "permissions",
   });
 
   // Fetch groups using useList hook
-  const { data: groupsData, isLoading: groupsLoading } = useList({
+  const { result: groupsResult, isLoading: groupsLoading } = useList({
     resource: "groups",
   });
 
-  const permissions = permissionsData?.data || [];
-  const groups = groupsData?.data || [];
+  const permissions = permissionsResult?.data || [];
+  const groups = groupsResult?.data || [];
 
   return (
     <Create saveButtonProps={saveButtonProps} isLoading={permissionsLoading || groupsLoading}>

--- a/src/pages/users/edit.tsx
+++ b/src/pages/users/edit.tsx
@@ -15,17 +15,17 @@ export const UserEdit: React.FC<IResourceComponentsProps> = () => {
   const [selectedGroups, setSelectedGroups] = useState<number[]>([]);
 
   // Fetch permissions using useList hook
-  const { data: permissionsData, isLoading: permissionsLoading } = useList({
+  const { result: permissionsResult, isLoading: permissionsLoading } = useList({
     resource: "permissions",
   });
 
   // Fetch groups using useList hook
-  const { data: groupsData, isLoading: groupsLoading } = useList({
+  const { result: groupsResult, isLoading: groupsLoading } = useList({
     resource: "groups",
   });
 
-  const permissions = permissionsData?.data.sort((a: any, b: any) => a.name.localeCompare(b.name)) || [];
-  const groups = groupsData?.data.sort((a: any, b: any) => a.name.localeCompare(b.name)) || [];
+  const permissions = permissionsResult?.data.sort((a: any, b: any) => a.name.localeCompare(b.name)) || [];
+  const groups = groupsResult?.data.sort((a: any, b: any) => a.name.localeCompare(b.name)) || [];
 
   // Set initial selected groups from record
   useEffect(() => {

--- a/src/pages/users/show.tsx
+++ b/src/pages/users/show.tsx
@@ -12,14 +12,16 @@ export const UserShow: React.FC<IResourceComponentsProps> = () => {
   const record = data?.data;
 
   // Fetch groups
-  const { data: groupsData } = useList({
+  const { result: groupsResult } = useList({
     resource: "groups",
   });
+  const groupsData = groupsResult?.data;
 
   // Fetch permissions
-  const { data: permissionsData } = useList({
+  const { result: permissionsResult } = useList({
     resource: "permissions",
   });
+  const permissionsData = permissionsResult?.data;
 
   // Map group IDs to names
   const groupNames = record?.groups?.map((groupId: number) => {

--- a/src/pages/variablesets/create.tsx
+++ b/src/pages/variablesets/create.tsx
@@ -8,12 +8,12 @@ export const VariableSetCreate: React.FC<IResourceComponentsProps> = () => {
   const [selectedVariables, setSelectedVariables] = useState<React.Key[]>([]);
 
   // Fetch variables using useList hook
-  const { data: variablesData, isLoading: variablesLoading } = useList({
+  const { result: variablesResult, isLoading: variablesLoading } = useList({
     resource: "variables",
     pagination: { mode: "off" },
   });
 
-  const variables = variablesData?.data || [];
+  const variables = variablesResult?.data || [];
 
   const handleTransferChange: TransferProps["onChange"] = (targetKeys) => {
     setSelectedVariables(targetKeys);

--- a/src/pages/variablesets/edit.tsx
+++ b/src/pages/variablesets/edit.tsx
@@ -8,12 +8,12 @@ export const VariableSetEdit: React.FC<IResourceComponentsProps> = () => {
   const [selectedVariables, setSelectedVariables] = useState<React.Key[]>([]);
 
   // Fetch variables using useList hook
-  const { data: variablesData, isLoading: variablesLoading } = useList({
+  const { result: variablesResult, isLoading: variablesLoading } = useList({
     resource: "variables",
     pagination: { mode: "off" },
   });
 
-  const variables = variablesData?.data || [];
+  const variables = variablesResult?.data || [];
   const variableSetData = queryResult?.data?.data;
 
   // Initialize selected variables when data is loaded

--- a/src/pages/variablesets/show.tsx
+++ b/src/pages/variablesets/show.tsx
@@ -12,7 +12,7 @@ export const VariableSetShow: React.FC<IResourceComponentsProps> = () => {
   const record = data?.data;
 
   // Fetch variables to get details for the variables in this set
-  const { data: variablesData } = useList({
+  const { result: variablesResult } = useList({
     resource: "variables",
     pagination: { mode: "off" },
     queryOptions: {
@@ -20,7 +20,7 @@ export const VariableSetShow: React.FC<IResourceComponentsProps> = () => {
     },
   });
 
-  const allVariables = variablesData?.data || [];
+  const allVariables = variablesResult?.data || [];
   const setVariables = allVariables.filter((variable) => record?.variables?.includes(variable.id));
 
   return (


### PR DESCRIPTION
- useList: data→result.data (12 calls across groups/users/variablesets pages)
- useMany: missed data→result.data in processes/show
- useParsed: identifier→id in file-upload-button and process-run-button
- notification: static API→App.useApp() for antd v5 + React 19 compat
- All 25 call sites across 12 files now use correct v5 return shapes