### PR TITLE
perf: add immutable cache headers for static assets

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -7,6 +7,11 @@ server {
   gzip_types text/css text/javascript application/javascript application/json image/svg+xml;
   gzip_min_length 1024;
 
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+
   location /media/ {
     alias /usr/share/nginx/media/;
   }

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -8,8 +8,7 @@ server {
   gzip_min_length 1024;
 
   location /assets/ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
   }
 
   location /media/ {


### PR DESCRIPTION
Content-hashed JS/CSS in /assets/ gets Cache-Control: immutable + 1-year expiry. Browser skips conditional revalidation — 0ms disk cache on repeat visits.