### PR TITLE
perf: migrate dashboard to React Query for caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@rjsf/core": "^6.6.2",
     "@rjsf/utils": "^6.6.2",
     "@rjsf/validator-ajv8": "^6.6.2",
+    "@tanstack/react-query": "^5.60.0",
     "antd": "^5.21.6",
     "axios": "^1.16.0",
     "axios-auth-refresh": "^3.3.6",

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -102,9 +102,7 @@ export const Dashboard = () => {
 
   const { data: favRunsRaw, isLoading: favRunsLoading, isError: favRunsError } = useQuery({
     queryKey: ["dashboard", "latest_runs", "favorites", processFavoriteIds.join(",")],
-    queryFn: () => axiosHelper.axiosInstance
-      .get(`${API_URL}/processes/latest_runs`, { params: { ids: processFavoriteIds.join(",") } })
-      .then(r => r.data),
+.get(`${API_URL}/processes/latest_runs`, { params: { ids: processFavoriteIds.join(",") }, timeout: 8000 })
     enabled: processFavoriteIds.length > 0,
     staleTime: 30_000,
     retry: 0,

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -12,7 +12,8 @@ import {
   ExclamationCircleOutlined,
 } from "@ant-design/icons";
 import { Link, useNavigate } from "react-router";
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import axiosHelper from "../../helpers/axios-token-interceptor";
 import { API_URL } from "../../config/constants";
 import { useFavorites } from "../../hooks/useFavorites";
@@ -57,29 +58,29 @@ export const Dashboard = () => {
   const [quickUploadSearch, setQuickUploadSearch] = useState("");
   const [showAllFavorites, setShowAllFavorites] = useState(false);
 
-  // --- fetch files & processes stats via axios (bypasses Refine caching issues) ---
-  const [fileList, setFileList] = useState<any[] | null>(null);
-  const [processList, setProcessList] = useState<any[]>([]);
-  const [isStatsLoading, setIsStatsLoading] = useState(true);
+  // --- fetch files & processes via React Query ---
+  const { data: filesRaw, isLoading: filesLoading } = useQuery({
+    queryKey: ["dashboard", "files"],
+    queryFn: () => axiosHelper.axiosInstance.get(`${API_URL}/files`).then(r => r.data),
+    staleTime: 10 * 60_000,
+    gcTime: 30 * 60_000,
+  });
+  const { data: processesRaw, isLoading: processesLoading } = useQuery({
+    queryKey: ["dashboard", "processes"],
+    queryFn: () => axiosHelper.axiosInstance.get(`${API_URL}/processes`).then(r => r.data),
+    staleTime: 10 * 60_000,
+    gcTime: 30 * 60_000,
+  });
 
-  useEffect(() => {
-    let cancelled = false;
-    setIsStatsLoading(true);
-    Promise.all([
-      axiosHelper.axiosInstance.get(`${API_URL}/files`),
-      axiosHelper.axiosInstance.get(`${API_URL}/processes`),
-    ])
-      .then(([fRes, pRes]) => {
-        if (cancelled) return;
-        setFileList(Array.isArray(fRes.data) ? fRes.data : fRes.data?.results ?? []);
-        const procs = Array.isArray(pRes.data) ? pRes.data : pRes.data?.results ?? [];
-        setProcessList(procs);
-        setIsStatsLoading(false);
-      })
-      .catch(() => { if (!cancelled) setIsStatsLoading(false); });
-    return () => { cancelled = true; };
-  }, []);
-  const latestRunsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fileList = useMemo(() => {
+    const data = filesRaw;
+    return Array.isArray(data) ? data : data?.results ?? null;
+  }, [filesRaw]);
+  const processList = useMemo(() => {
+    const data = processesRaw;
+    return Array.isArray(data) ? data : data?.results ?? [];
+  }, [processesRaw]);
+  const isStatsLoading = filesLoading || processesLoading;
 
   const allFavorites = useMemo(() => getAllFavorites(), [getAllFavorites]);
   const favoriteFileIds = useMemo(
@@ -95,77 +96,55 @@ export const Dashboard = () => {
   }, [fileList, favoriteFileIds]);
 
   // --- latest runs for favorited processes ---
-  const [latestRunsByProcessId, setLatestRunsByProcessId] = useState<Record<number, any>>({});
-  const [latestRunsLoaded, setLatestRunsLoaded] = useState(false);
-  const [latestRunsTimedOut, setLatestRunsTimedOut] = useState(false);
   const processFavoriteIds = allFavorites
     .filter((f) => f.resource === "processes")
     .map((f) => f.id);
 
-  useEffect(() => {
-    if (latestRunsTimer.current) clearTimeout(latestRunsTimer.current);
-    if (processFavoriteIds.length === 0) {
-      setLatestRunsLoaded(true);
-      setLatestRunsTimedOut(false);
-      return;
-    }
-    const ids = processFavoriteIds.join(",");
-    let cancelled = false;
-    setLatestRunsTimedOut(false);
-    latestRunsTimer.current = setTimeout(() => {
-      if (!cancelled) { setLatestRunsTimedOut(true); setLatestRunsLoaded(true); }
-    }, 8000);
-    axiosHelper.axiosInstance
-      .get(`${API_URL}/processes/latest_runs`, { params: { ids } })
-      .then(({ data }) => {
-        if (cancelled) return;
-        if (latestRunsTimer.current) clearTimeout(latestRunsTimer.current);
-        const map: Record<number, any> = {};
-        (data ?? []).forEach((item: any) => {
-          if (item.latest_run) map[item.process_id] = item.latest_run;
-        });
-        setLatestRunsByProcessId(map);
-        setLatestRunsLoaded(true);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          if (latestRunsTimer.current) clearTimeout(latestRunsTimer.current);
-          setLatestRunsTimedOut(true); setLatestRunsLoaded(true);
-        }
-      });
-    return () => { cancelled = true; if (latestRunsTimer.current) clearTimeout(latestRunsTimer.current); };
-  }, [processFavoriteIds.join(",")]);
+  const { data: favRunsRaw } = useQuery({
+    queryKey: ["dashboard", "latest_runs", "favorites", processFavoriteIds.join(",")],
+    queryFn: () => axiosHelper.axiosInstance
+      .get(`${API_URL}/processes/latest_runs`, { params: { ids: processFavoriteIds.join(",") } })
+      .then(r => r.data),
+    enabled: processFavoriteIds.length > 0,
+    staleTime: 30_000,
+  });
+
+  const latestRunsByProcessId = useMemo(() => {
+    const map: Record<number, any> = {};
+    (favRunsRaw ?? []).forEach((item: any) => {
+      if (item.latest_run) map[item.process_id] = item.latest_run;
+    });
+    return map;
+  }, [favRunsRaw]);
+  const latestRunsLoaded = processFavoriteIds.length === 0 || !!favRunsRaw;
+  const latestRunsTimedOut = false; // React Query handles timeouts internally
 
   // --- recent activity: latest runs across ALL processes ---
-  const [recentRuns, setRecentRuns] = useState<any[]>([]);
-  const [recentRunsLoading, setRecentRunsLoading] = useState(true);
   const allProcessIdsKey = processList.map((p: any) => p.id).filter(Boolean).join(",");
 
-  useEffect(() => {
-    if (!allProcessIdsKey) { setRecentRunsLoading(false); return; }
-    let cancelled = false;
-    setRecentRunsLoading(true);
-    axiosHelper.axiosInstance
+  const { data: recentRunsRaw, isLoading: recentRunsLoading } = useQuery({
+    queryKey: ["dashboard", "latest_runs", "all", allProcessIdsKey],
+    queryFn: () => axiosHelper.axiosInstance
       .get(`${API_URL}/processes/latest_runs`, { params: { ids: allProcessIdsKey } })
-      .then(({ data }) => {
-        if (cancelled) return;
-        const runs: any[] = [];
-        (data ?? []).forEach((item: any) => {
-          if (item.latest_run && item.latest_run.created_at) {
-            runs.push({
-              process_id: item.process_id,
-              process_code: processList.find((p: any) => p.id === item.process_id)?.code || `#${item.process_id}`,
-              ...item.latest_run,
-            });
-          }
+      .then(r => r.data),
+    enabled: !!allProcessIdsKey,
+    staleTime: 30_000,
+  });
+
+  const recentRuns = useMemo(() => {
+    const runs: any[] = [];
+    (recentRunsRaw ?? []).forEach((item: any) => {
+      if (item.latest_run && item.latest_run.created_at) {
+        runs.push({
+          process_id: item.process_id,
+          process_code: processList.find((p: any) => p.id === item.process_id)?.code || `#${item.process_id}`,
+          ...item.latest_run,
         });
-        runs.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-        setRecentRuns(runs.slice(0, 5));
-        setRecentRunsLoading(false);
-      })
-      .catch(() => { if (!cancelled) setRecentRunsLoading(false); });
-    return () => { cancelled = true; };
-  }, [allProcessIdsKey]);
+      }
+    });
+    runs.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    return runs.slice(0, 5);
+  }, [recentRunsRaw, processList]);
 
   // --- stats ---
   const runningCount = processList.filter((p: any) => {

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -100,13 +100,14 @@ export const Dashboard = () => {
     .filter((f) => f.resource === "processes")
     .map((f) => f.id);
 
-  const { data: favRunsRaw } = useQuery({
+  const { data: favRunsRaw, isLoading: favRunsLoading, isError: favRunsError } = useQuery({
     queryKey: ["dashboard", "latest_runs", "favorites", processFavoriteIds.join(",")],
     queryFn: () => axiosHelper.axiosInstance
       .get(`${API_URL}/processes/latest_runs`, { params: { ids: processFavoriteIds.join(",") } })
       .then(r => r.data),
     enabled: processFavoriteIds.length > 0,
     staleTime: 30_000,
+    retry: 0,
   });
 
   const latestRunsByProcessId = useMemo(() => {
@@ -116,13 +117,13 @@ export const Dashboard = () => {
     });
     return map;
   }, [favRunsRaw]);
-  const latestRunsLoaded = processFavoriteIds.length === 0 || !!favRunsRaw;
-  const latestRunsTimedOut = false; // React Query handles timeouts internally
+  const latestRunsLoaded = processFavoriteIds.length === 0 || !favRunsLoading;
+  const latestRunsTimedOut = favRunsError;
 
   // --- recent activity: latest runs across ALL processes ---
   const allProcessIdsKey = processList.map((p: any) => p.id).filter(Boolean).join(",");
 
-  const { data: recentRunsRaw, isLoading: recentRunsLoading } = useQuery({
+  const { data: recentRunsRaw, isLoading: recentRunsQueryLoading } = useQuery({
     queryKey: ["dashboard", "latest_runs", "all", allProcessIdsKey],
     queryFn: () => axiosHelper.axiosInstance
       .get(`${API_URL}/processes/latest_runs`, { params: { ids: allProcessIdsKey } })
@@ -130,6 +131,8 @@ export const Dashboard = () => {
     enabled: !!allProcessIdsKey,
     staleTime: 30_000,
   });
+
+  const recentRunsLoading = processesLoading || recentRunsQueryLoading;
 
   const recentRuns = useMemo(() => {
     const runs: any[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,10 +2169,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:5.101.2":
+  version: 5.101.2
+  resolution: "@tanstack/query-core@npm:5.101.2"
+  checksum: 10c0/c3288757bfd563ca35cee21bf6ed0edb2f4425a8c92f75d84dcb36a0580a59e48bd97fcdbbc7c8d8e95a4c40376edfc5772b14665b85d183079a0ba7e17793b2
+  languageName: node
+  linkType: hard
+
 "@tanstack/query-core@npm:5.90.12":
   version: 5.90.12
   resolution: "@tanstack/query-core@npm:5.90.12"
   checksum: 10c0/60d5dd23d7801118d6ef84a3d76e798aaf6eb851ee5227629a1dc798fa01ac9560580553413208fcc8a003fb12a89e83d6dd1f38ebc3bd9b6e8838cfaaa45fef
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.60.0":
+  version: 5.101.2
+  resolution: "@tanstack/react-query@npm:5.101.2"
+  dependencies:
+    "@tanstack/query-core": "npm:5.101.2"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/076b2db0d85a6dc96d461789715ae0df2e439d9a20a41e629446275f8177a856c3b89d242ad3d31eadaf421f080b9834bcd9f94e5143f4cd7f947a10af9e42b3
   languageName: node
   linkType: hard
 
@@ -8936,6 +8954,7 @@ __metadata:
     "@rjsf/core": "npm:^6.6.2"
     "@rjsf/utils": "npm:^6.6.2"
     "@rjsf/validator-ajv8": "npm:^6.6.2"
+    "@tanstack/react-query": "npm:^5.60.0"
     "@types/node": "npm:^24.10.1"
     "@types/pluralize": "npm:^0.0.33"
     "@types/react": "npm:^19.0.0"


### PR DESCRIPTION
Replace raw axios useEffect calls with useQuery hooks for files, processes, and latest_runs. Enables stale-while-revalidate: cached data shown instantly on re-visit, fresh data fetched silently in background.

- Files/Processes stats: 10min stale, 30min GC
- Latest runs (favorites + recent activity): 30s stale