### PR TITLE
fix: dark mode body/table backgrounds and CSS variable theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;300;500&display=swap" rel="stylesheet">
-  <style>
-    .ant-layout-header { background: var(--spade-surface, #ffffff) !important; }
-    .ant-layout-sider { background: var(--spade-surface, #ffffff) !important; }
-  </style>
 
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/favicons/apple-touch-icon-57x57.png" />
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/favicons/apple-touch-icon-114x114.png" />

--- a/src/contexts/theme-provider/index.tsx
+++ b/src/contexts/theme-provider/index.tsx
@@ -37,11 +37,11 @@ export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
       }
     };
 
-    setOrRemove("--spade-surface", "#11223f");
+    setOrRemove("--spade-surface", colors.colorBgContainer);
     setOrRemove("--spade-surface-soft", "#0f1d35");
-    setOrRemove("--spade-text", "#f2f6ff");
+    setOrRemove("--spade-text", colors.colorTextBase);
     setOrRemove("--spade-muted", "#7a8ba3");
-    setOrRemove("--spade-border", "#233f65");
+    setOrRemove("--spade-border", colors.colorBorder);
     setOrRemove("--spade-shadow", "0 6px 18px rgba(0, 0, 0, 0.25)");
   }, [mode]);
 

--- a/src/contexts/theme-provider/index.tsx
+++ b/src/contexts/theme-provider/index.tsx
@@ -21,28 +21,23 @@ export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   useLayoutEffect(() => {
     const colors = mode === "light" ? lightColors : darkColors;
-    document.body.style.backgroundColor = colors.colorBgLayout;
-    document.body.style.color = colors.colorTextBase;
-
-    // Only set --spade-* inline overrides for dark mode;
-    // in light mode remove them so stylesheet :root defaults remain the source of truth.
     const root = document.documentElement;
     const isDark = mode === "dark";
 
-    const setOrRemove = (prop: string, value: string) => {
-      if (isDark) {
-        root.style.setProperty(prop, value);
-      } else {
-        root.style.removeProperty(prop);
-      }
-    };
+    // Always set --spade-* from the current theme tokens so both
+    // light and dark stay in sync. SCSS :root defaults serve only as
+    // a no-JS / initial-load fallback.
+    root.style.setProperty("--spade-bg", colors.colorBgLayout);
+    root.style.setProperty("--spade-surface", colors.colorBgContainer);
+    root.style.setProperty("--spade-text", colors.colorTextBase);
+    root.style.setProperty("--spade-border", colors.colorBorder);
 
-    setOrRemove("--spade-surface", colors.colorBgContainer);
-    setOrRemove("--spade-surface-soft", "#0f1d35");
-    setOrRemove("--spade-text", colors.colorTextBase);
-    setOrRemove("--spade-muted", "#7a8ba3");
-    setOrRemove("--spade-border", colors.colorBorder);
-    setOrRemove("--spade-shadow", "0 6px 18px rgba(0, 0, 0, 0.25)");
+    // No direct antd token equivalents — use hardcoded dark/light pairs
+    root.style.setProperty("--spade-surface-soft", isDark ? "#0f1d35" : "#f7f9fc");
+    root.style.setProperty("--spade-muted", isDark ? "#7a8ba3" : "#5c6b83");
+    root.style.setProperty("--spade-shadow", isDark
+      ? "0 6px 18px rgba(0, 0, 0, 0.25)"
+      : "0 6px 18px rgba(19, 37, 70, 0.05)");
   }, [mode]);
 
   const setColorMode = () => {

--- a/src/contexts/theme-provider/index.tsx
+++ b/src/contexts/theme-provider/index.tsx
@@ -1,6 +1,6 @@
 import { RefineThemes } from "@refinedev/antd";
 import { ConfigProvider, theme } from "antd";
-import { PropsWithChildren, createContext, useEffect, useState } from "react";
+import { PropsWithChildren, createContext, useEffect, useLayoutEffect, useState } from "react";
 import { darkColors, lightColors } from "./colors";
 
 type ThemeProviderType = {
@@ -17,6 +17,22 @@ export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   useEffect(() => {
     window.localStorage.setItem("colorMode", mode);
+  }, [mode]);
+
+  useLayoutEffect(() => {
+    const colors = mode === "light" ? lightColors : darkColors;
+    document.body.style.backgroundColor = colors.colorBgLayout;
+    document.body.style.color = colors.colorTextBase;
+
+    // Update --spade-* CSS custom properties for dark/light mode
+    const root = document.documentElement;
+    const isDark = mode === "dark";
+    root.style.setProperty("--spade-surface", isDark ? "#11223f" : "#ffffff");
+    root.style.setProperty("--spade-surface-soft", isDark ? "#0f1d35" : "#f7f9fc");
+    root.style.setProperty("--spade-text", isDark ? "#f2f6ff" : "#18253d");
+    root.style.setProperty("--spade-muted", isDark ? "#7a8ba3" : "#5c6b83");
+    root.style.setProperty("--spade-border", isDark ? "#233f65" : "#d7deea");
+    root.style.setProperty("--spade-shadow", isDark ? "0 6px 18px rgba(0, 0, 0, 0.25)" : "0 6px 18px rgba(19, 37, 70, 0.05)");
   }, [mode]);
 
   const setColorMode = () => {

--- a/src/contexts/theme-provider/index.tsx
+++ b/src/contexts/theme-provider/index.tsx
@@ -24,15 +24,25 @@ export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
     document.body.style.backgroundColor = colors.colorBgLayout;
     document.body.style.color = colors.colorTextBase;
 
-    // Update --spade-* CSS custom properties for dark/light mode
+    // Only set --spade-* inline overrides for dark mode;
+    // in light mode remove them so stylesheet :root defaults remain the source of truth.
     const root = document.documentElement;
     const isDark = mode === "dark";
-    root.style.setProperty("--spade-surface", isDark ? "#11223f" : "#ffffff");
-    root.style.setProperty("--spade-surface-soft", isDark ? "#0f1d35" : "#f7f9fc");
-    root.style.setProperty("--spade-text", isDark ? "#f2f6ff" : "#18253d");
-    root.style.setProperty("--spade-muted", isDark ? "#7a8ba3" : "#5c6b83");
-    root.style.setProperty("--spade-border", isDark ? "#233f65" : "#d7deea");
-    root.style.setProperty("--spade-shadow", isDark ? "0 6px 18px rgba(0, 0, 0, 0.25)" : "0 6px 18px rgba(19, 37, 70, 0.05)");
+
+    const setOrRemove = (prop: string, value: string) => {
+      if (isDark) {
+        root.style.setProperty(prop, value);
+      } else {
+        root.style.removeProperty(prop);
+      }
+    };
+
+    setOrRemove("--spade-surface", "#11223f");
+    setOrRemove("--spade-surface-soft", "#0f1d35");
+    setOrRemove("--spade-text", "#f2f6ff");
+    setOrRemove("--spade-muted", "#7a8ba3");
+    setOrRemove("--spade-border", "#233f65");
+    setOrRemove("--spade-shadow", "0 6px 18px rgba(0, 0, 0, 0.25)");
   }, [mode]);
 
   const setColorMode = () => {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -29,6 +29,8 @@ body,
 body {
   margin: 0;
   font-family: "Manrope", "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--spade-text);
+  background: var(--spade-bg);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -29,8 +29,6 @@ body,
 body {
   margin: 0;
   font-family: "Manrope", "Avenir Next", "Segoe UI", sans-serif;
-  color: var(--spade-text);
-  background: var(--spade-bg);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }


### PR DESCRIPTION
- Remove hardcoded body background/color from styles.scss that overrode antd theme
- Set body backgroundColor/color via ThemeProvider useLayoutEffect
- Set --spade-* CSS custom properties on :root when theme changes: --spade-surface, --spade-text, --spade-muted, --spade-border, --spade-shadow now respond to dark/light mode instead of staying fixed to light values
- Remove hardcoded header/sider background overrides from index.html
- Fixes white table shells and white surfaces appearing in dark mode