### PR TITLE
feat: account-based favorites with API persistence

### DIFF
--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -76,8 +76,14 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
       resource: "processes",
       invalidates: ["list", "detail"],
     });
-    // Invalidate dashboard React Query cache so it picks up new run status
-    queryClient.invalidateQueries({ queryKey: ["dashboard", "latest_runs"] });
+    // Invalidate dashboard React Query cache after a short delay so the
+    // backend has time to actually start the process before we refetch.
+    const refetchLatestRuns = () => {
+      queryClient.invalidateQueries({ queryKey: ["dashboard", "latest_runs"] });
+    };
+    // First refetch after 1s (process started), then again after 4s
+    setTimeout(refetchLatestRuns, 1000);
+    setTimeout(refetchLatestRuns, 4000);
   };
 
   return (

--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -64,6 +64,20 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
             description: "Running",
           });
           setIsModalOpen(false);
+
+          // Optimistic update: immediately show "running" status in the
+          // dashboard / processes list before the API confirms it.
+          queryClient.setQueriesData(
+            { queryKey: ["dashboard", "latest_runs"], exact: false },
+            (old: any) => {
+              if (!Array.isArray(old)) return old;
+              return old.map((item: any) =>
+                item.process_id === targetId
+                  ? { ...item, latest_run: { ...item.latest_run, status: "running" } }
+                  : item
+              );
+            }
+          );
         },
       }
     );

--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -78,6 +78,14 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
               );
             }
           );
+
+          // Invalidate dashboard React Query cache after a short delay so
+          // the backend has time to start the process before we refetch.
+          const refetchLatestRuns = () => {
+            queryClient.invalidateQueries({ queryKey: ["dashboard", "latest_runs"] });
+          };
+          setTimeout(refetchLatestRuns, 1000);
+          setTimeout(refetchLatestRuns, 4000);
         },
       }
     );
@@ -90,14 +98,6 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
       resource: "processes",
       invalidates: ["list", "detail"],
     });
-    // Invalidate dashboard React Query cache after a short delay so the
-    // backend has time to actually start the process before we refetch.
-    const refetchLatestRuns = () => {
-      queryClient.invalidateQueries({ queryKey: ["dashboard", "latest_runs"] });
-    };
-    // First refetch after 1s (process started), then again after 4s
-    setTimeout(refetchLatestRuns, 1000);
-    setTimeout(refetchLatestRuns, 4000);
   };
 
   return (

--- a/src/components/process-run-button/index.tsx
+++ b/src/components/process-run-button/index.tsx
@@ -72,7 +72,7 @@ const ProcessRunButton: FC<ProcessRunButtonProps> = ({ buttonProps, recordItemId
             (old: any) => {
               if (!Array.isArray(old)) return old;
               return old.map((item: any) =>
-                item.process_id === targetId
+                String(item.process_id) === String(targetId)
                   ? { ...item, latest_run: { ...item.latest_run, status: "running" } }
                   : item
               );

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -3,7 +3,6 @@ import axiosHelper from "../helpers/axios-token-interceptor";
 import { API_URL } from "../config/constants";
 
 const STORAGE_KEY = "spade_favorites";
-const LABELS_KEY = "spade_favorite_labels";
 
 type Favorites = Record<string, number[]>;
 
@@ -29,23 +28,20 @@ async function syncFromAPI() {
     // overwriting the user's newer local state.
     if (localStorage.getItem(STORAGE_KEY) !== localBefore) return null;
     const favs: Favorites = {};
-    const labels: Record<string, string> = {};
     (data ?? []).forEach((f: any) => {
       if (!favs[f.resource]) favs[f.resource] = [];
       favs[f.resource].push(f.resource_id);
-      labels[`${f.resource}:${f.resource_id}`] = f.label || "";
     });
     saveFavorites(favs);
-    localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
     return favs;
   } catch {
     return null;
   }
 }
 
-async function addToAPI(resource: string, id: number, label: string) {
+async function addToAPI(resource: string, id: number) {
   try {
-    await axiosHelper.axiosInstance.post(`${API_URL}/favorites`, { resource, resource_id: id, label });
+    await axiosHelper.axiosInstance.post(`${API_URL}/favorites`, { resource, resource_id: id });
   } catch { /* silent */ }
 }
 
@@ -80,7 +76,7 @@ export function useFavorites() {
   );
 
   const toggleFavorite = useCallback(
-    (resource: string, id: number, label: string) => {
+    (resource: string, id: number, _label?: string) => {
       const current = loadFavorites();
       const ids = current[resource] || [];
       const wasFavorite = ids.includes(id);
@@ -90,22 +86,8 @@ export function useFavorites() {
         removeFromAPI(resource, id);
       } else {
         current[resource] = [...ids, id];
-        addToAPI(resource, id, label);
+        addToAPI(resource, id);
       }
-
-      // Update label cache
-      let labels: Record<string, string> = {};
-      try {
-        labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
-      } catch {
-        labels = {};
-      }
-      if (wasFavorite) {
-        delete labels[`${resource}:${id}`];
-      } else {
-        labels[`${resource}:${id}`] = label;
-      }
-      localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
 
       saveFavorites(current);
       setFavorites({ ...current });
@@ -120,20 +102,13 @@ export function useFavorites() {
   );
 
   const getAllFavorites = useCallback(() => {
-    let labels: Record<string, string> = {};
-    try {
-      labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
-    } catch {
-      labels = {};
-    }
-    const result = Object.entries(favorites).flatMap(([resource, ids]) =>
+    return Object.entries(favorites).flatMap(([resource, ids]) =>
       ids.map((id) => ({
         resource,
         id,
-        label: labels[`${resource}:${id}`] || `${resource}/${id}`,
+        label: `${resource}/${id}`,
       }))
     );
-    return result;
   }, [favorites]);
 
   return { isFavorite, toggleFavorite, getFavoriteIds, getAllFavorites, synced };

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -21,7 +21,13 @@ function saveFavorites(favs: Favorites) {
 
 async function syncFromAPI() {
   try {
+    // Snapshot localStorage before the request so we can detect concurrent
+    // local changes (e.g. user toggled a favorite while sync was in-flight).
+    const localBefore = localStorage.getItem(STORAGE_KEY);
     const { data } = await axiosHelper.axiosInstance.get(`${API_URL}/favorites`);
+    // If localStorage changed since we started, skip hydration to avoid
+    // overwriting the user's newer local state.
+    if (localStorage.getItem(STORAGE_KEY) !== localBefore) return null;
     const favs: Favorites = {};
     const labels: Record<string, string> = {};
     (data ?? []).forEach((f: any) => {
@@ -45,7 +51,9 @@ async function addToAPI(resource: string, id: number, label: string) {
 
 async function removeFromAPI(resource: string, id: number) {
   try {
-    await axiosHelper.axiosInstance.delete(`${API_URL}/favorites`, { data: { resource, resource_id: id } });
+    await axiosHelper.axiosInstance.delete(`${API_URL}/favorites`, {
+      params: { resource, resource_id: id },
+    });
   } catch { /* silent */ }
 }
 

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -63,10 +63,13 @@ export function useFavorites() {
 
   // Hydrate from API on mount
   useEffect(() => {
+    let cancelled = false;
     syncFromAPI().then((apiFavs) => {
+      if (cancelled) return;
       if (apiFavs) setFavorites(apiFavs);
       setSynced(true);
     });
+    return () => { cancelled = true; };
   }, []);
 
   const isFavorite = useCallback(

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,6 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import axiosHelper from "../helpers/axios-token-interceptor";
+import { API_URL } from "../config/constants";
 
 const STORAGE_KEY = "spade_favorites";
+const LABELS_KEY = "spade_favorite_labels";
 
 type Favorites = Record<string, number[]>;
 
@@ -16,8 +19,47 @@ function saveFavorites(favs: Favorites) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(favs));
 }
 
+async function syncFromAPI() {
+  try {
+    const { data } = await axiosHelper.axiosInstance.get(`${API_URL}/favorites`);
+    const favs: Favorites = {};
+    const labels: Record<string, string> = {};
+    (data ?? []).forEach((f: any) => {
+      if (!favs[f.resource]) favs[f.resource] = [];
+      favs[f.resource].push(f.resource_id);
+      labels[`${f.resource}:${f.resource_id}`] = f.label || "";
+    });
+    saveFavorites(favs);
+    localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
+    return favs;
+  } catch {
+    return null;
+  }
+}
+
+async function addToAPI(resource: string, id: number, label: string) {
+  try {
+    await axiosHelper.axiosInstance.post(`${API_URL}/favorites`, { resource, resource_id: id, label });
+  } catch { /* silent */ }
+}
+
+async function removeFromAPI(resource: string, id: number) {
+  try {
+    await axiosHelper.axiosInstance.delete(`${API_URL}/favorites`, { data: { resource, resource_id: id } });
+  } catch { /* silent */ }
+}
+
 export function useFavorites() {
   const [favorites, setFavorites] = useState<Favorites>(loadFavorites);
+  const [synced, setSynced] = useState(false);
+
+  // Hydrate from API on mount
+  useEffect(() => {
+    syncFromAPI().then((apiFavs) => {
+      if (apiFavs) setFavorites(apiFavs);
+      setSynced(true);
+    });
+  }, []);
 
   const isFavorite = useCallback(
     (resource: string, id: number) => {
@@ -34,28 +76,28 @@ export function useFavorites() {
 
       if (wasFavorite) {
         current[resource] = ids.filter((i) => i !== id);
+        removeFromAPI(resource, id);
       } else {
         current[resource] = [...ids, id];
+        addToAPI(resource, id, label);
       }
 
-      // Also store label for display
+      // Update label cache
       let labels: Record<string, string> = {};
       try {
-        labels = JSON.parse(localStorage.getItem("spade_favorite_labels") || "{}");
+        labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
       } catch {
         labels = {};
       }
-
       if (wasFavorite) {
         delete labels[`${resource}:${id}`];
       } else {
         labels[`${resource}:${id}`] = label;
       }
-      localStorage.setItem("spade_favorite_labels", JSON.stringify(labels));
+      localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
 
       saveFavorites(current);
       setFavorites({ ...current });
-      // Notify other components (e.g. sidebar badge)
       window.dispatchEvent(new Event("spade-favorites-changed"));
     },
     []
@@ -69,18 +111,19 @@ export function useFavorites() {
   const getAllFavorites = useCallback(() => {
     let labels: Record<string, string> = {};
     try {
-      labels = JSON.parse(localStorage.getItem("spade_favorite_labels") || "{}");
+      labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
     } catch {
       labels = {};
     }
-    return Object.entries(favorites).flatMap(([resource, ids]) =>
+    const result = Object.entries(favorites).flatMap(([resource, ids]) =>
       ids.map((id) => ({
         resource,
         id,
         label: labels[`${resource}:${id}`] || `${resource}/${id}`,
       }))
     );
+    return result;
   }, [favorites]);
 
-  return { isFavorite, toggleFavorite, getFavoriteIds, getAllFavorites };
+  return { isFavorite, toggleFavorite, getFavoriteIds, getAllFavorites, synced };
 }

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -107,7 +107,7 @@ export const Dashboard = () => {
       .get(`${API_URL}/processes/latest_runs`, { params: { ids: allProcessIdsKey } })
       .then(r => r.data),
     enabled: !!allProcessIdsKey,
-    staleTime: 10_000,
+    staleTime: 3_000,
     placeholderData: (prev: any) => prev,
     refetchOnMount: true,
     refetchInterval: (query) => {
@@ -115,7 +115,7 @@ export const Dashboard = () => {
       const hasRunning = (query.state.data as any[]).some((item: any) =>
         item.latest_run?.status === "running" || item.latest_run?.status === "new"
       );
-      return hasRunning ? 30_000 : false;
+      return hasRunning ? 10_000 : false;
     },
     retry: 0,
   });

--- a/src/pages/processes/list.tsx
+++ b/src/pages/processes/list.tsx
@@ -12,7 +12,7 @@ import { STATIC_QUERY_OPTIONS } from "../../config/query-cache";
 import { DEFAULT_PAGE_SIZE } from "../../config/rest-data-provider";
 import axiosHelper from "../../helpers/axios-token-interceptor";
 
-const ACTIVE_RUN_POLL_INTERVAL = 30_000;
+const ACTIVE_RUN_POLL_INTERVAL = 10_000;
 
 type LatestRun = { status?: string; result?: string; created_at?: string };
 
@@ -60,7 +60,7 @@ export const ProcessList: React.FC<IResourceComponentsProps> = () => {
       .get(`${API_URL}/processes/latest_runs`, { params: { ids: processIdsKey } })
       .then(r => r.data),
     enabled: !!processIdsKey,
-    staleTime: 10_000,
+    staleTime: 3_000,
     placeholderData: (prev: any) => prev,
     refetchOnMount: true,
     refetchInterval: (query) => {

--- a/src/pages/processes/list.tsx
+++ b/src/pages/processes/list.tsx
@@ -108,7 +108,7 @@ export const ProcessList: React.FC<IResourceComponentsProps> = () => {
   return (
     <List>
       <div className="processes-live-hint-wrap">
-        <div className="processes-live-hint">Live updates every 30 seconds while runs are active</div>
+        <div className="processes-live-hint">Live updates every 10 seconds while runs are active</div>
         {runningCount > 0 && (
           <Tag className="processes-live-counter">
             <span className="processes-live-counter__pulse" />


### PR DESCRIPTION
## Summary
Two changes bundled in this PR:

1. **Account-based favorites** — rewrite `useFavorites` hook to sync from
   the new `/api/v1/favorites` backend so favorites survive logout/login
   and are isolated per user account.

2. **Dashboard latency improvements** — reduce the time between running a
   process and seeing its status update on the dashboard/processes list.

### Commits
| Commit | Description |
|---|---|
| `4c29993` | feat: account-based favorites with API persistence |
| `2d5fb8e` | perf: reduce dashboard latest_runs latency after process run |
| `aee3f11` | perf: unify latest_runs poll/stale settings across pages |
| `2d962a1` | perf: optimistic cache update for instant run-status feedback |

### Details
- `useFavorites` syncs from API on mount, uses localStorage as cache
- `staleTime` 10s → 3s for latest_runs queries
- Poll interval 30s → 10s when runs are active
- Optimistic cache update: status chip shows "running" instantly on click
- Delayed invalidation: refetch at +1s and +4s after process start