### PR TITLE
fix: cache API labels in localStorage so dashboard shows real names

### DIFF
--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -36,7 +36,9 @@ async function syncFromAPI() {
       labels[`${f.resource}:${f.resource_id}`] = f.label || "";
     });
     saveFavorites(favs);
-    localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
+    try {
+      localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
+    } catch { /* ignore label cache failures */ }
     return favs;
   } catch {
     return null;
@@ -92,6 +94,24 @@ export function useFavorites() {
         current[resource] = [...ids, id];
         addToAPI(resource, id);
       }
+
+      // Update label cache immediately so the dashboard shows the real
+      // name without waiting for the next syncFromAPI.
+      const labelKey = `${resource}:${id}`;
+      let labels: Record<string, string> = {};
+      try {
+        labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
+      } catch {
+        labels = {};
+      }
+      if (wasFavorite) {
+        delete labels[labelKey];
+      } else if (_label) {
+        labels[labelKey] = _label;
+      }
+      try {
+        localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
+      } catch { /* ignore */ }
 
       saveFavorites(current);
       setFavorites({ ...current });

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -5,6 +5,16 @@ import { API_URL } from "../config/constants";
 const STORAGE_KEY = "spade_favorites";
 const LABELS_KEY = "spade_favorite_labels";
 
+function loadLabels(): Record<string, string> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
 type Favorites = Record<string, number[]>;
 
 function loadFavorites(): Favorites {
@@ -98,12 +108,7 @@ export function useFavorites() {
       // Update label cache immediately so the dashboard shows the real
       // name without waiting for the next syncFromAPI.
       const labelKey = `${resource}:${id}`;
-      let labels: Record<string, string> = {};
-      try {
-        labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
-      } catch {
-        labels = {};
-      }
+      const labels = loadLabels();
       if (wasFavorite) {
         delete labels[labelKey];
       } else if (_label) {
@@ -126,12 +131,7 @@ export function useFavorites() {
   );
 
   const getAllFavorites = useCallback(() => {
-    let labels: Record<string, string> = {};
-    try {
-      labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
-    } catch {
-      labels = {};
-    }
+    const labels = loadLabels();
     return Object.entries(favorites).flatMap(([resource, ids]) =>
       ids.map((id) => ({
         resource,

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -3,6 +3,7 @@ import axiosHelper from "../helpers/axios-token-interceptor";
 import { API_URL } from "../config/constants";
 
 const STORAGE_KEY = "spade_favorites";
+const LABELS_KEY = "spade_favorite_labels";
 
 type Favorites = Record<string, number[]>;
 
@@ -28,11 +29,14 @@ async function syncFromAPI() {
     // overwriting the user's newer local state.
     if (localStorage.getItem(STORAGE_KEY) !== localBefore) return null;
     const favs: Favorites = {};
+    const labels: Record<string, string> = {};
     (data ?? []).forEach((f: any) => {
       if (!favs[f.resource]) favs[f.resource] = [];
       favs[f.resource].push(f.resource_id);
+      labels[`${f.resource}:${f.resource_id}`] = f.label || "";
     });
     saveFavorites(favs);
+    localStorage.setItem(LABELS_KEY, JSON.stringify(labels));
     return favs;
   } catch {
     return null;
@@ -102,11 +106,17 @@ export function useFavorites() {
   );
 
   const getAllFavorites = useCallback(() => {
+    let labels: Record<string, string> = {};
+    try {
+      labels = JSON.parse(localStorage.getItem(LABELS_KEY) || "{}");
+    } catch {
+      labels = {};
+    }
     return Object.entries(favorites).flatMap(([resource, ids]) =>
       ids.map((id) => ({
         resource,
         id,
-        label: `${resource}/${id}`,
+        label: labels[`${resource}:${id}`] || `${resource}/${id}`,
       }))
     );
   }, [favorites]);

--- a/src/pages/users/show.tsx
+++ b/src/pages/users/show.tsx
@@ -24,16 +24,16 @@ export const UserShow: React.FC<IResourceComponentsProps> = () => {
   const permissionsData = permissionsResult?.data;
 
   // Map group IDs to names
-  const groupNames = record?.groups?.map((groupId: number) => {
+  const groupNames = (record?.groups?.map((groupId: number) => {
     const group = groupsData?.data?.find((g: any) => g.id === groupId);
     return group ? group.name : groupId.toString();
-  }).sort((a: string, b: string) => a.localeCompare(b));
+  }) ?? []).sort((a: string, b: string) => a.localeCompare(b));
 
   // Map permission IDs to names
-  const permissionNames = record?.user_permissions?.map((permissionId: number) => {
+  const permissionNames = (record?.user_permissions?.map((permissionId: number) => {
     const permission = permissionsData?.data?.find((p: any) => p.id === permissionId);
     return permission ? permission.name : permissionId.toString();
-  }).sort((a: string, b: string) => a.localeCompare(b));
+  }) ?? []).sort((a: string, b: string) => a.localeCompare(b));
 
   return (
     <Show isLoading={isLoading}>

--- a/src/pages/users/show.tsx
+++ b/src/pages/users/show.tsx
@@ -25,13 +25,13 @@ export const UserShow: React.FC<IResourceComponentsProps> = () => {
 
   // Map group IDs to names
   const groupNames = record?.groups?.map((groupId: number) => {
-    const group = groupsData?.data.find((g: any) => g.id === groupId);
+    const group = groupsData?.data?.find((g: any) => g.id === groupId);
     return group ? group.name : groupId.toString();
   }).sort((a: string, b: string) => a.localeCompare(b));
 
   // Map permission IDs to names
   const permissionNames = record?.user_permissions?.map((permissionId: number) => {
-    const permission = permissionsData?.data.find((p: any) => p.id === permissionId);
+    const permission = permissionsData?.data?.find((p: any) => p.id === permissionId);
     return permission ? permission.name : permissionId.toString();
   }).sort((a: string, b: string) => a.localeCompare(b));
 


### PR DESCRIPTION
Restore LABELS_KEY caching from syncFromAPI response. The API now returns live labels via Subquery — cache them so getAllFavorites shows actual file/process codes instead of fallback strings.