### PR TITLE
Display user information in history tab

### DIFF
--- a/src/pages/files/show.tsx
+++ b/src/pages/files/show.tsx
@@ -276,7 +276,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
             dataIndex={["user"]}
             title="User"
             render={(value) =>
-              userIsLoading ? <>Loading...</> : userData?.data?.find((item) => item.id === value)?.email
+              userIsLoading ? <>Loading...</> : userData?.find((item) => item.id === value)?.email
             }
             sorter
           />

--- a/src/pages/processes/show.tsx
+++ b/src/pages/processes/show.tsx
@@ -246,7 +246,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
             dataIndex={["user"]}
             title="User"
             render={(value) =>
-              userIsLoading ? <>Loading...</> : userData?.data?.find((item) => item.id === value)?.email
+              userIsLoading ? <>Loading...</> : userData?.find((item) => item.id === value)?.email
             }
             sorter
           />


### PR DESCRIPTION
This pull request makes a minor adjustment to how user data is accessed when displaying user emails in the `FileShow` and `ProcessShow` components. The change simplifies the data structure by removing the unnecessary `.data` property access.

Data access simplification:

* Updated the `render` function in both `FileShow` (`src/pages/files/show.tsx`) and `ProcessShow` (`src/pages/processes/show.tsx`) to access `userData` directly, instead of `userData.data`, when finding the user's email. [[1]](diffhunk://#diff-7de20e3e1b3d5b0bddde0ff27779aa60751c630de8b2c24c9d0a2d6feeeb744eL279-R279) [[2]](diffhunk://#diff-0be0e2107ac91e0fd37068e072c50204e349f15c23bb0432a577fdb983346b4bL249-R249)