### PR TITLE
hotfix: fix status chip defaults and add missing --idle CSS

### DIFF
--- a/src/pages/files/show.tsx
+++ b/src/pages/files/show.tsx
@@ -106,7 +106,7 @@ export const FileShow: React.FC<IResourceComponentsProps> = () => {
     )
       return "failed";
     if (normalizedResult === "success" || normalizedStatus === "finished") return "success";
-    return "failed";
+    return "idle";
   };
 
   const definitionsTab = (

--- a/src/pages/processes/show.tsx
+++ b/src/pages/processes/show.tsx
@@ -93,7 +93,7 @@ export const ProcessShow: React.FC<IResourceComponentsProps> = () => {
     )
       return "failed";
     if (normalizedResult === "success" || normalizedStatus === "finished") return "success";
-    return "failed";
+    return "idle";
   };
 
   const definitionsTab = (

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -461,6 +461,12 @@ body {
   box-shadow: 0 0 0 2px rgba(var(--spade-running-rgb), 0.16);
 }
 
+.run-status-chip--idle {
+  color: var(--spade-muted);
+  border-color: rgba(128, 128, 128, 0.3);
+  background: rgba(128, 128, 128, 0.08);
+}
+
 .entity-table-row--running td {
   background: rgba(var(--spade-running-rgb), 0.09) !important;
 }


### PR DESCRIPTION
- Change getRunState default from 'failed' to 'idle' in processes/show.tsx
- Change getRunState default from 'failed' to 'idle' in files/show.tsx
- Add .run-status-chip--idle CSS class for consistent grey chip styling